### PR TITLE
[Design/build logic]

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,86 +1,18 @@
-import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
-
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
-    alias(libs.plugins.ktlint)
-    alias(libs.plugins.hilt)
-    kotlin("kapt")
+    id("buildlogic.appmodule")
 }
 
 android {
     namespace = "com.hobbyloop.member"
-    compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloop.member"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-}
-
-ktlint {
-    android = true
-    ignoreFailures = false
-    reporters {
-        reporter(ReporterType.PLAIN)
-        reporter(ReporterType.CHECKSTYLE)
-        reporter(ReporterType.SARIF)
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.kotlinxCollections)
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.hilt)
-    implementation(project(":feature:facility-card"))
-    kapt(libs.bundles.hiltCompiler)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":feature:login"))
     implementation(project(":feature:signup"))
     implementation(project(":feature:home"))
     implementation(project(":feature:facility"))
+    implementation(project(":feature:facility-card"))
     implementation(project(":feature:reservation"))
     implementation(project(":feature:storage"))
     implementation(project(":feature:my-page"))
-
-    lintChecks(libs.compose.lint.checks)
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,3 +13,12 @@ dependencies {
     compileOnly(libs.android.tools.build.gradle.plugin)
     compileOnly(libs.kotlin.gradle.plugin)
 }
+
+gradlePlugin {
+    plugins {
+        register("appModule") {
+            id = "buildlogic.appmodule"
+            implementationClass = "AppModuleConventions"
+        }
+    }
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,5 +28,9 @@ gradlePlugin {
             id = "buildlogic.featuremodule"
             implementationClass = "FeatureModuleConventions"
         }
+        register("uiModule") {
+            id = "buildlogic.uimodule"
+            implementationClass = "UiModuleConventions"
+        }
     }
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -24,5 +24,9 @@ gradlePlugin {
             id = "buildlogic.datamodule"
             implementationClass = "DataModuleConventions"
         }
+        register("featureModule") {
+            id = "buildlogic.featuremodule"
+            implementationClass = "FeatureModuleConventions"
+        }
     }
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -20,5 +20,9 @@ gradlePlugin {
             id = "buildlogic.appmodule"
             implementationClass = "AppModuleConventions"
         }
+        register("dataModule") {
+            id = "buildlogic.datamodule"
+            implementationClass = "DataModuleConventions"
+        }
     }
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    `kotlin-dsl`
+}
+
+group = "com.hobbyloopapp.buildlogic"
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    compileOnly(libs.android.tools.build.gradle.plugin)
+    compileOnly(libs.kotlin.gradle.plugin)
+}

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configureondemand=true

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,11 @@
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/AppModuleConventions.kt
+++ b/build-logic/src/main/kotlin/AppModuleConventions.kt
@@ -1,0 +1,58 @@
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import internal.configureAndroid
+import internal.configureAndroidTest
+import internal.configureCompose
+import internal.configureConvention
+import internal.configureHilt
+import internal.configureKotlinExtensions
+import internal.configureNavigation
+import internal.configureUnitTest
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class AppModuleConventions : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        with(pluginManager) {
+            apply("com.android.application")
+            apply("org.jlleitschuh.gradle.ktlint")
+        }
+
+        extensions.configure<BaseAppModuleExtension> {
+            defaultConfig {
+                applicationId = "com.hobbyloop.member"
+                targetSdk = 34
+                versionCode = 1
+                versionName = "1.0"
+
+                testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                vectorDrawables {
+                    useSupportLibrary = true
+                }
+            }
+            buildTypes {
+                release {
+                    isMinifyEnabled = false
+                    proguardFiles(
+                        getDefaultProguardFile("proguard-android-optimize.txt"),
+                        "proguard-rules.pro"
+                    )
+                }
+            }
+            packaging {
+                resources {
+                    excludes += "/META-INF/{AL2.0,LGPL2.1}"
+                }
+            }
+        }
+
+        configureAndroid<BaseAppModuleExtension>()
+        configureCompose<BaseAppModuleExtension>()
+        configureNavigation()
+        configureHilt()
+        configureKotlinExtensions()
+        configureAndroidTest()
+        configureUnitTest()
+        configureConvention()
+    }
+}

--- a/build-logic/src/main/kotlin/DataModuleConventions.kt
+++ b/build-logic/src/main/kotlin/DataModuleConventions.kt
@@ -1,0 +1,22 @@
+import com.android.build.api.dsl.LibraryExtension
+import internal.configureAndroid
+import internal.configureAndroidTest
+import internal.configureHilt
+import internal.configureKotlinExtensions
+import internal.configureUnitTest
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class DataModuleConventions : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        with(pluginManager) {
+            apply("com.android.library")
+        }
+
+        configureAndroid<LibraryExtension>()
+        configureHilt()
+        configureKotlinExtensions()
+        configureAndroidTest()
+        configureUnitTest()
+    }
+}

--- a/build-logic/src/main/kotlin/FeatureModuleConventions.kt
+++ b/build-logic/src/main/kotlin/FeatureModuleConventions.kt
@@ -1,0 +1,26 @@
+import com.android.build.api.dsl.LibraryExtension
+import internal.configureAndroid
+import internal.configureAndroidTest
+import internal.configureCompose
+import internal.configureHilt
+import internal.configureKotlinExtensions
+import internal.configureNavigation
+import internal.configureUnitTest
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class FeatureModuleConventions : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        with(pluginManager) {
+            apply("com.android.library")
+        }
+
+        configureAndroid<LibraryExtension>()
+        configureCompose<LibraryExtension>()
+        configureNavigation()
+        configureKotlinExtensions()
+        configureHilt()
+        configureAndroidTest()
+        configureUnitTest()
+    }
+}

--- a/build-logic/src/main/kotlin/UiModuleConventions.kt
+++ b/build-logic/src/main/kotlin/UiModuleConventions.kt
@@ -1,0 +1,20 @@
+import com.android.build.api.dsl.LibraryExtension
+import internal.configureAndroid
+import internal.configureCompose
+import internal.configureKotlinExtensions
+import internal.configureNavigation
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class UiModuleConventions : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        with(pluginManager) {
+            apply("com.android.library")
+        }
+
+        configureAndroid<LibraryExtension>()
+        configureCompose<LibraryExtension>()
+        configureNavigation()
+        configureKotlinExtensions()
+    }
+}

--- a/build-logic/src/main/kotlin/internal/Android.kt
+++ b/build-logic/src/main/kotlin/internal/Android.kt
@@ -1,0 +1,33 @@
+package internal
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.plugin.KaptExtension
+
+internal inline fun <reified T : CommonExtension<*, *, *, *, *>> Project.configureAndroid() {
+    with(pluginManager) {
+        apply("org.jetbrains.kotlin.android")
+        apply("org.jetbrains.kotlin.kapt")
+    }
+
+    extensions.configure<T> {
+        compileSdk = 34
+
+        defaultConfig {
+            minSdk = 24
+        }
+
+        compileOptions {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
+    }
+
+    val kaptExtension = extensions.getByType<KaptExtension>()
+    kaptExtension.apply {
+        correctErrorTypes = true
+    }
+}

--- a/build-logic/src/main/kotlin/internal/AndroidTest.kt
+++ b/build-logic/src/main/kotlin/internal/AndroidTest.kt
@@ -1,0 +1,13 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureAndroidTest() {
+    dependencies {
+        add("androidTestImplementation", platform(getLibrary("compose-bom")))
+        add("androidTestImplementation", getLibrary("androidx-test-ext-junit"))
+        add("androidTestImplementation", getLibrary("espresso-core"))
+        add("androidTestImplementation", getLibrary("ui-test-junit4"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/Compose.kt
+++ b/build-logic/src/main/kotlin/internal/Compose.kt
@@ -1,0 +1,29 @@
+package internal
+
+import com.android.build.api.dsl.CommonExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+
+internal inline fun <reified T : CommonExtension<*, *, *, *, *>> Project.configureCompose() {
+    extensions.configure<T> {
+        buildFeatures {
+            compose = true
+        }
+        composeOptions {
+            kotlinCompilerExtensionVersion = "1.5.1"
+        }
+    }
+
+    dependencies {
+        add("implementation", platform(getLibrary("compose-bom")))
+        add("implementation", getLibrary("ui"))
+        add("implementation", getLibrary("ui-graphics"))
+        add("implementation", getLibrary("ui-tooling-preview"))
+        add("implementation", getLibrary("material3"))
+        add("implementation", getLibrary("material"))
+        add("implementation", getLibrary("lifecycle-runtime-ktx"))
+        add("implementation", getLibrary("activity-compose"))
+        add("debugImplementation", getLibrary("ui-tooling"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/Convention.kt
+++ b/build-logic/src/main/kotlin/internal/Convention.kt
@@ -1,0 +1,10 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureConvention() {
+    dependencies {
+        add("lintChecks", getLibrary("compose-lint-checks"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/Hilt.kt
+++ b/build-logic/src/main/kotlin/internal/Hilt.kt
@@ -1,0 +1,15 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureHilt() {
+    with(pluginManager) {
+        apply("dagger.hilt.android.plugin")
+    }
+
+    dependencies {
+        add("implementation", getLibrary("hilt"))
+        add("kapt", getLibrary("hilt.compiler"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/KotlinExtension.kt
+++ b/build-logic/src/main/kotlin/internal/KotlinExtension.kt
@@ -1,0 +1,10 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureKotlinExtensions() {
+    dependencies {
+        add("implementation", getLibrary("kotlinx-collections-immutable"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/Navigation.kt
+++ b/build-logic/src/main/kotlin/internal/Navigation.kt
@@ -1,0 +1,11 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureNavigation() {
+    dependencies {
+        add("implementation", getLibrary("hilt-navigation-compose"))
+        add("implementation", getLibrary("compose-navigation"))
+    }
+}

--- a/build-logic/src/main/kotlin/internal/ProjectExtension.kt
+++ b/build-logic/src/main/kotlin/internal/ProjectExtension.kt
@@ -1,0 +1,11 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+internal val Project.libs
+    get(): VersionCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal fun Project.getLibrary(name: String) = libs.findLibrary(name).get()

--- a/build-logic/src/main/kotlin/internal/UnitTest.kt
+++ b/build-logic/src/main/kotlin/internal/UnitTest.kt
@@ -1,0 +1,10 @@
+package internal
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+internal fun Project.configureUnitTest() {
+    dependencies {
+        add("testImplementation", getLibrary("junit"))
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.hilt) apply false
+    alias(libs.plugins.ktlint) apply true
 }
-true // Needed to make the Suppress annotation work for the plugins block

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,46 +1,7 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.datamodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.core.data"
-    compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.data"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
-dependencies {
-
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -1,46 +1,15 @@
 plugins {
-    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }
 
 android {
     namespace = "com.hobbyloopapp.core.database"
     compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.database"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {
-
-    implementation(libs.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    /**
+     * 추후 라이브러리 의존성 관리를 build-logic 모듈에서 하도록 함
+     */
 }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -1,46 +1,15 @@
 plugins {
-    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }
 
 android {
     namespace = "com.hobbyloopapp.core.datastore"
     compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.datastore"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {
-
-    implementation(libs.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    /**
+     * 추후 라이브러리 의존성 관리를 build-logic 모듈에서 하도록 함
+     */
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,46 +1,15 @@
 plugins {
-    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }
 
 android {
     namespace = "com.hobbyloopapp.core.domain"
     compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.domain"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {
-
-    implementation(libs.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    /**
+     * 추후 라이브러리 의존성 관리를 build-logic 모듈에서 하도록 함
+     */
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,46 +1,15 @@
 plugins {
-    alias(libs.plugins.androidApplication)
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }
 
 android {
     namespace = "com.hobbyloopapp.core.network"
     compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.network"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {
-
-    implementation(libs.core.ktx)
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
+    /**
+     * 추후 라이브러리 의존성 관리를 build-logic 모듈에서 하도록 함
+     */
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,46 +1,11 @@
 plugins {
-    alias(libs.plugins.androidApplication)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.uimodule")
 }
+
 
 android {
     namespace = "com.hobbyloopapp.core.ui"
-    compileSdk = 34
-
-    defaultConfig {
-        applicationId = "com.hobbyloopapp.core.ui"
-        minSdk = 24
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
-
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {
-
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
 }

--- a/feature/facility-card/build.gradle.kts
+++ b/feature/facility-card/build.gradle.kts
@@ -1,58 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
-    kotlin("kapt")
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.facility_card"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.hilt)
-    kapt(libs.bundles.hiltCompiler)
-    implementation(libs.bundles.navigation)
-
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/facility/build.gradle.kts
+++ b/feature/facility/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.facility"
-    compileSdk = 34
-
-    defaultConfig {
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        minSdk = 24
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.home"
-    compileSdk = 34
+}
 
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-        buildFeatures {
-            compose = true
-        }
-        composeOptions {
-            kotlinCompilerExtensionVersion = "1.5.1"
-        }
-        packaging {
-            resources {
-                excludes += "/META-INF/{AL2.0,LGPL2.1}"
-            }
-        }
-    }
-
-    dependencies {
-        implementation(platform(libs.compose.bom))
-        implementation(libs.bundles.ui)
-        implementation(libs.bundles.navigation)
-        testImplementation(libs.bundles.test)
-        androidTestImplementation(libs.bundles.androidTest)
-        debugImplementation(libs.bundles.debugImple)
-
-        implementation(project(":core:ui"))
-    }
+dependencies {
+    implementation(project(":core:ui"))
 }

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.login"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/my-page/build.gradle.kts
+++ b/feature/my-page/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.my_page"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/reservation/build.gradle.kts
+++ b/feature/reservation/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.reservation"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/signup/build.gradle.kts
+++ b/feature/signup/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobbyloopapp.feature.signup"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/feature/storage/build.gradle.kts
+++ b/feature/storage/build.gradle.kts
@@ -1,53 +1,11 @@
 plugins {
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.kotlinAndroid)
+    id("buildlogic.featuremodule")
 }
 
 android {
     namespace = "com.hobboyloopapp.feature.storage"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.bundles.ui)
-    implementation(libs.bundles.navigation)
-    testImplementation(libs.bundles.test)
-    androidTestImplementation(libs.bundles.androidTest)
-    debugImplementation(libs.bundles.debugImple)
-
     implementation(project(":core:ui"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,9 @@ hilt-navigation-compose = "1.1.0"
 kotlinx-collections-immutable = "0.3.6"
 
 [libraries]
-compose-lint-checks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "compose-lint-checks" }
+android-tools-build-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+compose-lint-checks = { group = "com.slack.lint.compose", name = "compose-lint-checks", version.ref = "compose-lint-checks" }
+kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         google()
         mavenCentral()
@@ -14,13 +15,16 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "hobbyloopmember"
+
 include(":app")
+
 include(":core:data")
 include(":core:database")
 include(":core:datastore")
 include(":core:network")
 include(":core:ui")
 include(":core:domain")
+
 include(":feature:login")
 include(":feature:signup")
 include(":feature:home")


### PR DESCRIPTION
### (해당 브랜치는 develop 브랜치에 병합하는 용도가 아닌 전체 네비게이션 설계 코드 공유용입니다.)

## [작업] 
build logic 모듈을 사용하여 각 모듈의 빌드 구성을 해결하고 모든 빌드 스크립트를 중앙에서 관리하도록 함
==> 빌드 시간 단축, 프로젝트의 일관성 유지, 예기치 않은 오류를 줄이며 관리를 간편하게 할 수 있음